### PR TITLE
Replace CLAUDE.md symlink with an AGENTS.md import

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,3 @@
-AGENTS.md
+@AGENTS.md
+
+This file exists so Claude Code discovers the project rules. The canonical file is AGENTS.md. If AGENTS.md is already in context, do not read this file again.


### PR DESCRIPTION
## Summary

`CLAUDE.md` was a symlink to `AGENTS.md`. Tools and agents that load every recognized instruction filename then ingested the same rules twice.

This replaces the symlink with a short pointer:

```markdown
@AGENTS.md
```

Claude Code still discovers `CLAUDE.md` and imports the canonical rules. Other agents can treat this file as a pointer instead of a second copy. That avoids accidentally reading both files and wasting tokens.

## How to verify

- `CLAUDE.md` is a regular file, not a symlink
- It starts with `@AGENTS.md`
- `AGENTS.md` is unchanged
